### PR TITLE
fix: removing cwd path from static options

### DIFF
--- a/src/react-router.ts
+++ b/src/react-router.ts
@@ -64,7 +64,7 @@ export async function reactRouter(
 		elysia.use(
 			staticPlugin({
 				prefix: "/",
-				assets: join(buildDirectory, "client"),
+				assets: join(options?.buildDirectory ?? "build", "client"),
 				headers: { "Cache-Control": "public, max-age=31536000, immutable" },
 				...options?.production?.assets,
 			}),

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -69,7 +69,7 @@ export async function remix(
 		elysia.use(
 			staticPlugin({
 				prefix: "/",
-				assets: join(buildDirectory, "client"),
+				assets: join(options?.buildDirectory ?? "build", "client"),
 				headers: { "Cache-Control": "public, max-age=31536000, immutable" },
 				...options?.production?.assets,
 			}),


### PR DESCRIPTION
buildDirectory has cwd added in it. but elysia static plugin needs asset path without cwd.