### PR TITLE
fix: removing cache-control from elysia static options.

### DIFF
--- a/src/react-router.ts
+++ b/src/react-router.ts
@@ -65,7 +65,7 @@ export async function reactRouter(
 			staticPlugin({
 				prefix: "/",
 				assets: join(options?.buildDirectory ?? "build", "client"),
-				maxAge: 60 * 60 * 24 * 30,
+				maxAge: 31536000,
 				...options?.production?.assets,
 			}),
 		);

--- a/src/react-router.ts
+++ b/src/react-router.ts
@@ -65,7 +65,7 @@ export async function reactRouter(
 			staticPlugin({
 				prefix: "/",
 				assets: join(options?.buildDirectory ?? "build", "client"),
-				headers: { "Cache-Control": "public, max-age=31536000, immutable" },
+				maxAge: 60 * 60 * 24 * 30,
 				...options?.production?.assets,
 			}),
 		);

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -70,7 +70,7 @@ export async function remix(
 			staticPlugin({
 				prefix: "/",
 				assets: join(options?.buildDirectory ?? "build", "client"),
-				headers: { "Cache-Control": "public, max-age=31536000, immutable" },
+				maxAge: 60 * 60 * 24 * 30,
 				...options?.production?.assets,
 			}),
 		);

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -70,7 +70,7 @@ export async function remix(
 			staticPlugin({
 				prefix: "/",
 				assets: join(options?.buildDirectory ?? "build", "client"),
-				maxAge: 60 * 60 * 24 * 30,
+				maxAge: 31536000,
 				...options?.production?.assets,
 			}),
 		);


### PR DESCRIPTION
adding headers: { "Cache-Control": "public, max-age=31536000, immutable" } in elysia static plugin will take no effect in cache control, since elysia static plugin options has maxAge prop to pass to set cach-control max-age.
```/**
     * @default 86400
     *
     * Specifies the maximum amount of time in seconds, a resource will be considered fresh.
     * This freshness lifetime is calculated relative to the time of the request.
     * This setting helps control browser caching behavior.
     * A `maxAge` of 0 will prevent caching, requiring requests to validate with the server before use.
     */
    maxAge?: number | null;
